### PR TITLE
화면 전환 및 호불호 선택 기능 구현

### DIFF
--- a/lib/models/dislike_category.dart
+++ b/lib/models/dislike_category.dart
@@ -1,0 +1,14 @@
+enum DislikeCategory { 
+  seafood,     // 해산물
+  meat,        // 육류
+  beef,        // 소고기
+  pork,        // 돼지고기
+  chicken,     // 닭고기
+  fish,        // 생선
+  spicy,       // 매운음식
+  sweet,       // 단음식
+  salty,       // 짠음식
+  cold,        // 찬음식
+  hot,         // 뜨거운음식
+  dairy,       // 유제품
+} 

--- a/lib/models/menu.dart
+++ b/lib/models/menu.dart
@@ -4,6 +4,12 @@ class Menu {
   final String id;
   final String name;
   final Category category;
+  final String? imageUrl;
 
-  Menu({required this.id, required this.name, required this.category});
+  Menu({
+    required this.id, 
+    required this.name, 
+    required this.category,
+    this.imageUrl,
+  });
 }

--- a/lib/viewmodels/lotto_viewmodel.dart
+++ b/lib/viewmodels/lotto_viewmodel.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../game/lottery_game.dart';
 import '../models/menu.dart';
+import '../models/category.dart';
+import '../models/dislike_category.dart';
 import '../services/history_service.dart';
 import '../services/menu_selection_service.dart';
 
@@ -40,6 +42,10 @@ class LottoViewModel extends ChangeNotifier {
   bool isLotteryRunning = false;
   Menu? selectedMenu;
 
+  // 선호도 관리
+  Set<Category> _preferredCategories = <Category>{};
+  Set<DislikeCategory> _dislikedCategories = <DislikeCategory>{};
+
   // 결과 화면 네비게이션을 위한 콜백
   Function? onGameComplete;
 
@@ -49,6 +55,40 @@ class LottoViewModel extends ChangeNotifier {
   }) : _historyService = historyService,
        _menuSelectionService = menuSelectionService;
 
+  // 선호도 getter
+  Set<Category> get preferredCategories => Set.from(_preferredCategories);
+  Set<DislikeCategory> get dislikedCategories => Set.from(_dislikedCategories);
+
+  // 선호도 업데이트 메서드
+  void updatePreferredCategories(Set<Category> categories) {
+    debugPrint('=== 선호도 업데이트 ===');
+    debugPrint('이전 선호도: ${_preferredCategories.map((c) => c.name).toList()}');
+    debugPrint('새로운 선호도: ${categories.map((c) => c.name).toList()}');
+    
+    _preferredCategories = Set.from(categories);
+    
+    debugPrint('최종 선호도: ${_preferredCategories.map((c) => c.name).toList()}');
+    debugPrint('최종 불호도: ${_dislikedCategories.map((c) => c.name).toList()}');
+    debugPrint('===================\n');
+    
+    notifyListeners();
+  }
+
+  // 불호도 업데이트 메서드
+  void updateDislikedCategories(Set<DislikeCategory> categories) {
+    debugPrint('=== 불호도 업데이트 ===');
+    debugPrint('이전 불호도: ${_dislikedCategories.map((c) => c.name).toList()}');
+    debugPrint('새로운 불호도: ${categories.map((c) => c.name).toList()}');
+    
+    _dislikedCategories = Set.from(categories);
+    
+    debugPrint('최종 선호도: ${_preferredCategories.map((c) => c.name).toList()}');
+    debugPrint('최종 불호도: ${_dislikedCategories.map((c) => c.name).toList()}');
+    debugPrint('===================\n');
+    
+    notifyListeners();
+  }
+  
   // 게임 인스턴스에 대한 안전한 getter
   LotteryGame? get lotteryGame => _lotteryGame;
 

--- a/lib/views/lotto_screen.dart
+++ b/lib/views/lotto_screen.dart
@@ -6,6 +6,7 @@ import '../design/theme.dart';
 import '../game/lottery_game.dart';
 import '../viewmodels/lotto_viewmodel.dart';
 import '../widgets/lottery_machine.dart';
+import '../widgets/preference_bottom_sheet.dart';
 import 'result_screen.dart';
 
 class LottoScreen extends StatefulWidget {
@@ -166,6 +167,40 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
     }
   }
 
+  // 선호도 선택 BottomSheet 표시
+  void _showPreferenceBottomSheet() {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => PreferenceBottomSheet(
+        title: '선호 확인',
+        isPreference: true,
+        initialSelectedPreferences: _viewModel.preferredCategories,
+        onConfirmPreferences: (selectedCategories) {
+          _viewModel.updatePreferredCategories(selectedCategories);
+        },
+      ),
+    );
+  }
+
+  // 불호도 선택 BottomSheet 표시
+  void _showDislikeBottomSheet() {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => PreferenceBottomSheet(
+        title: '불호 확인',
+        isPreference: false,
+        initialSelectedDislikes: _viewModel.dislikedCategories,
+        onConfirmDislikes: (selectedCategories) {
+          _viewModel.updateDislikedCategories(selectedCategories);
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<LottoViewModel>(
@@ -271,6 +306,7 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
                                   ),
                                   onPressed: () {
                                     // TODO: 선호 선택 기능 구현
+                                    _showPreferenceBottomSheet();
                                   },
                                   child: const Text(
                                     '선호 선택',
@@ -296,6 +332,7 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
                                   ),
                                   onPressed: () {
                                     // TODO: 블록 선택 기능 구현
+                                    _showDislikeBottomSheet();
                                   },
                                   child: const Text(
                                     '불호 선택',

--- a/lib/views/lotto_screen.dart
+++ b/lib/views/lotto_screen.dart
@@ -176,19 +176,34 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
         return Scaffold(
           backgroundColor: AppTheme.backgroundColor,
           appBar: AppBar(
-            title: const Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                'Pick Eat',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  color: AppTheme.primaryColor,
-                ),
+            title: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '추천 메뉴 뽑기',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                      fontSize: 20,
+                    ),
+                  ),
+                  Text(
+                    '오늘 먹을 메뉴를 뽑아보세요',
+                    style: TextStyle(
+                      color: Colors.white70,
+                      fontSize: 14,
+                      fontWeight: FontWeight.normal,
+                    ),
+                  ),
+                ],
               ),
             ),
-            backgroundColor: Colors.transparent,
+            backgroundColor: Colors.red.shade400,
             elevation: 0,
             centerTitle: false,
+            toolbarHeight: 80,
           ),
           body: SafeArea(
             child: Column(
@@ -210,14 +225,91 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
                           : const LotteryMachine(),
                 ),
 
-                // 액션 버튼
+                // 액션 버튼들
                 if (!viewModel.isLotteryRunning)
                   Padding(
                     padding: const EdgeInsets.all(24.0),
-                    child: ElevatedButton(
-                      style: AppTheme.primaryButtonStyle,
-                      onPressed: () => _startLottery(),
-                      child: Text('메뉴 뽑기', style: AppTheme.buttonText),
+                    child: Column(
+                      children: [
+                        // 메인 뽑기 버튼
+                        SizedBox(
+                          width: double.infinity,
+                          height: 50,
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.red.shade400,
+                              foregroundColor: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(25),
+                              ),
+                              elevation: 0,
+                            ),
+                            onPressed: () => _startLottery(),
+                            child: const Text(
+                              '뽑기',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        // 하단 두 개 버튼
+                        Row(
+                          children: [
+                            Expanded(
+                              child: SizedBox(
+                                height: 45,
+                                child: OutlinedButton(
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor: Colors.red.shade400,
+                                    side: BorderSide(color: Colors.red.shade400),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(22.5),
+                                    ),
+                                  ),
+                                  onPressed: () {
+                                    // TODO: 선호 선택 기능 구현
+                                  },
+                                  child: const Text(
+                                    '선호 선택',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: SizedBox(
+                                height: 45,
+                                child: OutlinedButton(
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor: Colors.red.shade400,
+                                    side: BorderSide(color: Colors.red.shade400),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(22.5),
+                                    ),
+                                  ),
+                                  onPressed: () {
+                                    // TODO: 블록 선택 기능 구현
+                                  },
+                                  child: const Text(
+                                    '불호 선택',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
                   ),
               ],

--- a/lib/views/lotto_screen.dart
+++ b/lib/views/lotto_screen.dart
@@ -7,7 +7,7 @@ import '../game/lottery_game.dart';
 import '../viewmodels/lotto_viewmodel.dart';
 import '../widgets/lottery_machine.dart';
 import '../widgets/preference_bottom_sheet.dart';
-import 'result_screen.dart';
+import '../widgets/menu_card.dart';
 
 class LottoScreen extends StatefulWidget {
   const LottoScreen({super.key});
@@ -58,34 +58,14 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
       _viewModel = Provider.of<LottoViewModel>(context, listen: false);
       _viewModel.onGameComplete = () {
         if (mounted) {
-          _navigateToResult(context, _viewModel);
+          // 게임 완료 시 게임 위젯 숨기기만 함 (네비게이션 제거)
+          setState(() {
+            _showGameWidget = false;
+          });
+          _cleanupGameInstance();
         }
       };
       _callbackRegistered = true;
-    }
-  }
-
-  // 메뉴 선택 후 결과 화면으로 이동하는 메서드
-  void _navigateToResult(BuildContext context, LottoViewModel viewModel) async {
-    // 게임 위젯 즉시 숨기기
-    if (mounted) {
-      setState(() {
-        _showGameWidget = false;
-      });
-    }
-
-    // UI 업데이트 보장
-    await Future.microtask(() {});
-
-    // 게임 인스턴스 정리
-    _cleanupGameInstance();
-
-    if (mounted && viewModel.selectedMenu != null) {
-      await Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (context) => ResultScreen(menu: viewModel.selectedMenu!),
-        ),
-      );
     }
   }
 
@@ -114,7 +94,7 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
       // 새 게임 인스턴스 생성
       final instance = LotteryGame();
 
-      // 공 선택 완료 시 히스토리 처리 및 결과 화면 이동
+      // 공 선택 완료 시 히스토리 처리
       instance.onBallSelected = () async {
         if (_viewModel.isLotteryRunning) {
           // 뽑기 상태 업데이트
@@ -126,9 +106,9 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
             await _viewModel.addMenuToHistory(_viewModel.selectedMenu!);
           }
 
-          // 결과 화면으로 이동
+          // 게임 완료 콜백 호출 (결과 화면 표시용)
           if (mounted) {
-            _navigateToResult(context, _viewModel);
+            _viewModel.onGameComplete?.call();
           }
         }
       };
@@ -165,6 +145,17 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
     if (mounted && _gameInstance != null && _viewModel.isLotteryRunning) {
       _gameInstance!.startLottery();
     }
+  }
+
+  // 다시 뽑기 메서드
+  void _retryLottery() async {
+    setState(() {
+      _showGameWidget = false;
+    });
+    _cleanupGameInstance();
+    
+    // 리셋 후 바로 새로운 뽑기 시작
+    await _startLottery();
   }
 
   // 선호도 선택 BottomSheet 표시
@@ -213,11 +204,14 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
           appBar: AppBar(
             title: Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
-              child: const Column(
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    '추천 메뉴 뽑기',
+                    // 메뉴가 뽑힌 상태에서는 다른 제목 표시
+                    viewModel.selectedMenu != null && !viewModel.isLotteryRunning
+                        ? '오늘의 추천 메뉴'
+                        : '추천 메뉴 뽑기',
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
                       color: Colors.white,
@@ -225,7 +219,10 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
                     ),
                   ),
                   Text(
-                    '오늘 먹을 메뉴를 뽑아보세요',
+                    // 메뉴가 뽑힌 상태에서는 다른 설명 표시
+                    viewModel.selectedMenu != null && !viewModel.isLotteryRunning
+                        ? '이런 메뉴는 어떠신가요?'
+                        : '오늘 먹을 메뉴를 뽑아보세요',
                     style: TextStyle(
                       color: Colors.white70,
                       fontSize: 14,
@@ -243,117 +240,143 @@ class _LottoScreenState extends State<LottoScreen> with WidgetsBindingObserver {
           body: SafeArea(
             child: Column(
               children: [
-                // 뽑기 머신 (게임 영역)
+                // 메인 컨텐츠 영역 - 조건부 렌더링
                 Expanded(
-                  child:
-                      viewModel.isLotteryRunning
-                          ? _showGameWidget && _gameInstance != null
-                              ? Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 24,
-                                ),
-                                child: ClipRect(
-                                  child: GameWidget(game: _gameInstance!),
-                                ),
-                              )
-                              : const Center(child: CircularProgressIndicator())
-                          : const LotteryMachine(),
+                  child: _buildMainContent(viewModel),
                 ),
 
-                // 액션 버튼들
-                if (!viewModel.isLotteryRunning)
-                  Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      children: [
-                        // 메인 뽑기 버튼
-                        SizedBox(
-                          width: double.infinity,
-                          height: 50,
-                          child: ElevatedButton(
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.red.shade400,
-                              foregroundColor: Colors.white,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(25),
-                              ),
-                              elevation: 0,
-                            ),
-                            onPressed: () => _startLottery(),
-                            child: const Text(
-                              '뽑기',
-                              style: TextStyle(
-                                fontSize: 18,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 12),
-                        // 하단 두 개 버튼
-                        Row(
-                          children: [
-                            Expanded(
-                              child: SizedBox(
-                                height: 45,
-                                child: OutlinedButton(
-                                  style: OutlinedButton.styleFrom(
-                                    foregroundColor: Colors.red.shade400,
-                                    side: BorderSide(color: Colors.red.shade400),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(22.5),
-                                    ),
-                                  ),
-                                  onPressed: () {
-                                    // TODO: 선호 선택 기능 구현
-                                    _showPreferenceBottomSheet();
-                                  },
-                                  child: const Text(
-                                    '선호 선택',
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: SizedBox(
-                                height: 45,
-                                child: OutlinedButton(
-                                  style: OutlinedButton.styleFrom(
-                                    foregroundColor: Colors.red.shade400,
-                                    side: BorderSide(color: Colors.red.shade400),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(22.5),
-                                    ),
-                                  ),
-                                  onPressed: () {
-                                    // TODO: 블록 선택 기능 구현
-                                    _showDislikeBottomSheet();
-                                  },
-                                  child: const Text(
-                                    '불호 선택',
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
+                // 하단 버튼 영역 - 조건부 렌더링
+                _buildBottomButtons(viewModel),
               ],
             ),
           ),
         );
       },
+    );
+  }
+
+  // 메인 컨텐츠 빌드 (조건부 렌더링)
+  Widget _buildMainContent(LottoViewModel viewModel) {
+    // 뽑힌 메뉴가 있고 뽑기가 실행중이 아닌 경우 → 결과 카드 표시
+    if (viewModel.selectedMenu != null && !viewModel.isLotteryRunning) {
+      return Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SizedBox(height: 30),
+            MenuCard(menu: viewModel.selectedMenu!),
+            const Spacer(),
+          ],
+        ),
+      );
+    }
+    
+    // 뽑기 실행 중인 경우 → 게임 위젯 표시
+    if (viewModel.isLotteryRunning) {
+      return _showGameWidget && _gameInstance != null
+          ? Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: ClipRect(
+                child: GameWidget(game: _gameInstance!),
+              ),
+            )
+          : const Center(child: CircularProgressIndicator());
+    }
+    
+    // 기본 상태 → 로또 머신 표시
+    return const LotteryMachine();
+  }
+
+  // 하단 버튼 빌드 (조건부 렌더링)
+  Widget _buildBottomButtons(LottoViewModel viewModel) {
+    return Padding(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        children: [
+          // 메인 버튼
+          SizedBox(
+            width: double.infinity,
+            height: 50,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red.shade400,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(25),
+                ),
+                elevation: 0,
+              ),
+              onPressed: viewModel.isLotteryRunning 
+                  ? null 
+                  : (viewModel.selectedMenu != null 
+                      ? _retryLottery 
+                      : _startLottery),
+              child: Text(
+                viewModel.selectedMenu != null ? '다시 뽑기' : '뽑기',
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+          
+          // 뽑기 실행 중이 아닐 때만 하단 두 버튼 표시
+          if (!viewModel.isLotteryRunning) ...[
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: SizedBox(
+                    height: 45,
+                    child: OutlinedButton(
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.red.shade400,
+                        side: BorderSide(color: Colors.red.shade400),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(22.5),
+                        ),
+                      ),
+                      onPressed: _showPreferenceBottomSheet,
+                      child: const Text(
+                        '선호 선택',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: SizedBox(
+                    height: 45,
+                    child: OutlinedButton(
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.red.shade400,
+                        side: BorderSide(color: Colors.red.shade400),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(22.5),
+                        ),
+                      ),
+                      onPressed: _showDislikeBottomSheet,
+                      child: const Text(
+                        '불호 선택',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
     );
   }
 }

--- a/lib/views/result_screen.dart
+++ b/lib/views/result_screen.dart
@@ -18,36 +18,44 @@ class ResultScreen extends StatelessWidget {
       create: (_) => ResultViewModel(menu: menu),
       child: Consumer<ResultViewModel>(
         builder: (context, viewModel, child) {
+
           return Scaffold(
             backgroundColor: AppTheme.backgroundColor,
+            appBar: AppBar(
+            title: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '추천 메뉴 뽑기',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                      fontSize: 20,
+                    ),
+                  ),
+                  Text(
+                    '오늘 먹을 메뉴를 뽑아보세요',
+                    style: TextStyle(
+                      color: Colors.white70,
+                      fontSize: 14,
+                      fontWeight: FontWeight.normal,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            backgroundColor: Colors.red.shade400,
+            elevation: 0,
+            centerTitle: false,
+            toolbarHeight: 80,
+          ),
             body: SafeArea(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  // 상단 헤더
-                  Container(
-                    padding: const EdgeInsets.symmetric(vertical: 20),
-                    color: AppTheme.primaryColor,
-                    child: Column(
-                      children: [
-                        Text(
-                          '오늘의 추천 메뉴',
-                          style: AppTheme.titleSmall.copyWith(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '행복한 점심 시간 되세요!',
-                          style: AppTheme.bodySmall.copyWith(
-                            color: const Color.fromRGBO(255, 255, 255, 0.8),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
+                
                   // 메인 컨텐츠
                   Expanded(
                     child: Padding(
@@ -57,57 +65,174 @@ class ResultScreen extends StatelessWidget {
                         children: [
                           const SizedBox(height: 30),
 
-                          // 메뉴 아이콘
-                          Icon(
-                            Icons.restaurant,
-                            size: 80,
-                            color: AppTheme.primaryColor,
-                          ),
-
-                          const SizedBox(height: 30),
-
-                          // 메뉴 이름
-                          Text(
-                            viewModel.menu.name,
-                            style: AppTheme.titleLarge,
-                            textAlign: TextAlign.center,
-                          ),
-
-                          const SizedBox(height: 10),
-
-                          // 메뉴 설명
-                          Text(
-                            '오늘은 ${viewModel.menu.name}(을)를 추천합니다',
-                            style: AppTheme.bodyMedium.copyWith(
-                              color: AppTheme.textSecondary,
+                          // 메뉴 카드
+                          Card(
+                            elevation: 8,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(20),
                             ),
-                            textAlign: TextAlign.center,
+                            child: Container(
+                              width: double.infinity,
+                              padding: const EdgeInsets.all(32.0),
+                              child: Column(
+                                children: [
+                                  // 음식 이미지 또는 아이콘
+                                  Container(
+                                    width: 120,
+                                    height: 120,
+                                    decoration: BoxDecoration(
+                                      color: Colors.grey.shade100,
+                                      borderRadius: BorderRadius.circular(60),
+                                    ),
+                                    child: viewModel.menu.imageUrl != null
+                                        ? ClipRRect(
+                                            borderRadius: BorderRadius.circular(60),
+                                            child: Image.network(
+                                              viewModel.menu.imageUrl!,
+                                              fit: BoxFit.cover,
+                                              errorBuilder: (context, error, stackTrace) {
+                                                return Icon(
+                                                  Icons.restaurant,
+                                                  size: 60,
+                                                  color: Colors.red.shade400,
+                                                );
+                                              },
+                                            ),
+                                          )
+                                        : Icon(
+                                            Icons.restaurant,
+                                            size: 60,
+                                            color: Colors.red.shade400,
+                                          ),
+                                  ),
+
+                                  const SizedBox(height: 24),
+
+                                  // 메뉴 이름
+                                  Text(
+                                    viewModel.menu.name,
+                                    style: TextStyle(
+                                      fontSize: 28,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.black87,
+                                    ),
+                                    textAlign: TextAlign.center,
+                                  ),
+
+                                  const SizedBox(height: 12),
+
+                                  // 메뉴 설명
+                                  Text(
+                                    '오늘은 ${viewModel.menu.name} 어떠신가요?',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      color: Colors.grey.shade600,
+                                    ),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ],
+                              ),
+                            ),
                           ),
 
                           const Spacer(),
 
-                          // 버튼
-                          ElevatedButton(
-                            style: AppTheme.primaryButtonStyle,
-                            onPressed: () {
-                              // 홈 화면으로 돌아가기 전에 상태 초기화
-                              final lottoViewModel = Provider.of<LottoViewModel>(
-                                context,
-                                listen: false,
-                              );
-                              lottoViewModel.reset();
+                          // 버튼들
+                          Column(
+                            children: [
+                              // 메인 버튼 - 다시 뽑기
+                              SizedBox(
+                                width: double.infinity,
+                                height: 50,
+                                child: ElevatedButton(
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: Colors.red.shade400,
+                                    foregroundColor: Colors.white,
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(25),
+                                    ),
+                                    elevation: 0,
+                                  ),
+                                  onPressed: () {
+                                    // 홈 화면으로 돌아가기 전에 상태 초기화
+                                    final lottoViewModel = Provider.of<LottoViewModel>(
+                                      context,
+                                      listen: false,
+                                    );
+                                    lottoViewModel.reset();
 
-                              // 홈 화면으로 돌아가기
-                              Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (context) => LottoScreen(),
+                                    // 홈 화면으로 돌아가기
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute(
+                                        builder: (context) => LottoScreen(),
+                                      ),
+                                    );
+                                  },
+                                  child: Text(
+                                    '다시 뽑기',
+                                    style: TextStyle(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
                                 ),
-                              );
-                            },
-                            child: Text(
-                              '홈 화면으로 돌아가기',
-                              style: AppTheme.buttonText,
-                            ),
+                              ),
+                              const SizedBox(height: 12),
+                              // 하단 두 개 버튼
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: SizedBox(
+                                      height: 45,
+                                      child: OutlinedButton(
+                                        style: OutlinedButton.styleFrom(
+                                          foregroundColor: Colors.red.shade400,
+                                          side: BorderSide(color: Colors.red.shade400),
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius: BorderRadius.circular(22.5),
+                                          ),
+                                        ),
+                                        onPressed: () {
+                                          // TODO: 선호 저장 기능 구현
+                                        },
+                                        child: const Text(
+                                          '선호 재선택',
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: SizedBox(
+                                      height: 45,
+                                      child: OutlinedButton(
+                                        style: OutlinedButton.styleFrom(
+                                          foregroundColor: Colors.red.shade400,
+                                          side: BorderSide(color: Colors.red.shade400),
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius: BorderRadius.circular(22.5),
+                                          ),
+                                        ),
+                                        onPressed: () {
+                                          // TODO: 불호 저장 기능 구현
+                                        },
+                                        child: const Text(
+                                          '불호 재선택',
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
                           ),
                         ],
                       ),

--- a/lib/widgets/menu_card.dart
+++ b/lib/widgets/menu_card.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../models/menu.dart';
+
+class MenuCard extends StatelessWidget {
+  final Menu menu;
+  final VoidCallback? onRetry;
+  final String? description;
+
+  const MenuCard({
+    super.key,
+    required this.menu,
+    this.onRetry,
+    this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 8,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          children: [
+            // 음식 이미지 또는 아이콘
+            Container(
+              width: 120,
+              height: 120,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: BorderRadius.circular(60),
+              ),
+              child: menu.imageUrl != null
+                  ? ClipRRect(
+                      borderRadius: BorderRadius.circular(60),
+                      child: Image.network(
+                        menu.imageUrl!,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) {
+                          return Icon(
+                            Icons.restaurant,
+                            size: 60,
+                            color: Colors.red.shade400,
+                          );
+                        },
+                      ),
+                    )
+                  : Icon(
+                      Icons.restaurant,
+                      size: 60,
+                      color: Colors.red.shade400,
+                    ),
+            ),
+
+            const SizedBox(height: 24),
+
+            // 메뉴 이름
+            Text(
+              menu.name,
+              style: TextStyle(
+                fontSize: 28,
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+              textAlign: TextAlign.center,
+            ),
+
+            const SizedBox(height: 12),
+
+            // 메뉴 설명
+            Text(
+              description ?? '오늘은 ${menu.name} 어떠신가요?',
+              style: TextStyle(
+                fontSize: 16,
+                color: Colors.grey.shade600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+} 

--- a/lib/widgets/preference_bottom_sheet.dart
+++ b/lib/widgets/preference_bottom_sheet.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import '../models/category.dart';
+import '../models/dislike_category.dart';
+
+class PreferenceBottomSheet extends StatefulWidget {
+  final String title;
+  final bool isPreference; // true: 선호도, false: 불호도
+  final Set<Category> initialSelectedPreferences;
+  final Set<DislikeCategory> initialSelectedDislikes;
+  final Function(Set<Category>)? onConfirmPreferences;
+  final Function(Set<DislikeCategory>)? onConfirmDislikes;
+
+  const PreferenceBottomSheet({
+    super.key,
+    required this.title,
+    required this.isPreference,
+    this.initialSelectedPreferences = const {},
+    this.initialSelectedDislikes = const {},
+    this.onConfirmPreferences,
+    this.onConfirmDislikes,
+  });
+
+  @override
+  State<PreferenceBottomSheet> createState() => _PreferenceBottomSheetState();
+}
+
+class _PreferenceBottomSheetState extends State<PreferenceBottomSheet> {
+  late Set<Category> _selectedPreferences;
+  late Set<DislikeCategory> _selectedDislikes;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedPreferences = Set.from(widget.initialSelectedPreferences);
+    _selectedDislikes = Set.from(widget.initialSelectedDislikes);
+  }
+
+  String _getCategoryDisplayName(Category category) {
+    switch (category) {
+      case Category.korean:
+        return '한식';
+      case Category.chinese:
+        return '중식';
+      case Category.japanese:
+        return '일식';
+      case Category.western:
+        return '양식';
+      case Category.fastFood:
+        return '패스트푸드';
+      case Category.others:
+        return '기타';
+      default:
+        return '그 외';
+    }
+  }
+
+  String _getDislikeCategoryDisplayName(DislikeCategory category) {
+    switch (category) {
+      case DislikeCategory.seafood:
+        return '해산물';
+      case DislikeCategory.meat:
+        return '육류';
+      case DislikeCategory.beef:
+        return '소고기';
+      case DislikeCategory.pork:
+        return '돼지고기';
+      case DislikeCategory.chicken:
+        return '닭고기';
+      case DislikeCategory.fish:
+        return '생선';
+      case DislikeCategory.spicy:
+        return '매운음식';
+      case DislikeCategory.sweet:
+        return '단음식';
+      case DislikeCategory.salty:
+        return '짠음식';
+      case DislikeCategory.cold:
+        return '찬음식';
+      case DislikeCategory.hot:
+        return '뜨거운음식';
+      case DislikeCategory.dairy:
+        return '유제품';
+      default:
+        return '그 외';
+    }
+  }
+
+  String get _getDescriptionText {
+    if (widget.isPreference) {
+      return '좋아하는 음식을 선택해주세요';
+    } else {
+      return '싫어하는 음식을 선택해주세요';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final maxHeight = screenHeight * 0.7;
+    
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20),
+          topRight: Radius.circular(20),
+        ),
+      ),
+      margin: const EdgeInsets.only(left: 10, right: 10),
+      constraints: BoxConstraints(
+        maxHeight: maxHeight,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 상단 핸들
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: Colors.grey.shade300,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+
+          // 타이틀
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              children: [
+                Text(
+                  widget.title,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black87,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  _getDescriptionText,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.grey.shade600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // 카테고리 리스트 (스크롤 가능)
+          Expanded(
+            child: 
+              ScrollbarTheme(data: ScrollbarThemeData(
+                crossAxisMargin: 10,
+              ), child: 
+            Scrollbar(
+              thumbVisibility: true,
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Column(
+                  children: [
+                    if (widget.isPreference)
+                      // 선호도 리스트
+                      ...Category.values.asMap().entries.map((entry) {
+                        final index = entry.key;
+                        final category = entry.value;
+                        final isSelected = _selectedPreferences.contains(category);
+                        final isLast = index == Category.values.length - 1;
+                        
+                        return Column(
+                          children: [
+                            Container(
+                              margin: const EdgeInsets.only(bottom: 8),
+                              child: CheckboxListTile(
+                                title: Text(
+                                  _getCategoryDisplayName(category),
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                value: isSelected,
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    if (value == true) {
+                                      _selectedPreferences.add(category);
+                                    } else {
+                                      _selectedPreferences.remove(category);
+                                    }
+                                  });
+                                },
+                                activeColor: Colors.red.shade400,
+                                checkColor: Colors.white,
+                                controlAffinity: ListTileControlAffinity.trailing,
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 0,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(12),
+                                  side: BorderSide(
+                                    color: isSelected 
+                                        ? Colors.red.shade400 
+                                        : Colors.grey.shade300,
+                                    width: 1.5,
+                                  ),
+                                ),
+                                tileColor: isSelected 
+                                    ? Colors.red.shade50 
+                                    : Colors.transparent,
+                              ),
+                            ),
+                            // 점선 구분선 (마지막 아이템이 아닐 때만)
+                            if (!isLast)
+                              Container(
+                                margin: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 0,
+                                ),
+                                child: CustomPaint(
+                                  size: const Size(double.infinity, 1),
+                                  painter: DashedLinePainter(),
+                                ),
+                              ),
+                          ],
+                        );
+                      })
+                    else
+                      // 불호도 리스트
+                      ...DislikeCategory.values.asMap().entries.map((entry) {
+                        final index = entry.key;
+                        final category = entry.value;
+                        final isSelected = _selectedDislikes.contains(category);
+                        final isLast = index == DislikeCategory.values.length - 1;
+                        
+                        return Column(
+                          children: [
+                            Container(
+                              margin: const EdgeInsets.only(bottom: 8),
+                              child: CheckboxListTile(
+                                title: Text(
+                                  _getDislikeCategoryDisplayName(category),
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                value: isSelected,
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    if (value == true) {
+                                      _selectedDislikes.add(category);
+                                    } else {
+                                      _selectedDislikes.remove(category);
+                                    }
+                                  });
+                                },
+                                activeColor: Colors.red.shade400,
+                                checkColor: Colors.white,
+                                controlAffinity: ListTileControlAffinity.trailing,
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 0,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(12),
+                                  side: BorderSide(
+                                    color: isSelected 
+                                        ? Colors.red.shade400 
+                                        : Colors.grey.shade300,
+                                    width: 1.5,
+                                  ),
+                                ),
+                                tileColor: isSelected 
+                                    ? Colors.red.shade50 
+                                    : Colors.transparent,
+                              ),
+                            ),
+                            // 점선 구분선 (마지막 아이템이 아닐 때만)
+                            if (!isLast)
+                              Container(
+                                margin: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 0,
+                                ),
+                                child: CustomPaint(
+                                  size: const Size(double.infinity, 1),
+                                  painter: DashedLinePainter(),
+                                ),
+                              ),
+                          ],
+                        );
+                      }),
+                  ],
+                ),
+              ),
+            ),
+            ),
+          ),
+
+          // 확인 버튼
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: SizedBox(
+              width: double.infinity,
+              height: 50,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red.shade400,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(25),
+                  ),
+                  elevation: 0,
+                ),
+                onPressed: () {
+                  if (widget.isPreference) {
+                    widget.onConfirmPreferences?.call(_selectedPreferences);
+                  } else {
+                    widget.onConfirmDislikes?.call(_selectedDislikes);
+                  }
+                  Navigator.of(context).pop();
+                },
+                child: const Text(
+                  '확인',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          // 하단 안전 영역
+          SizedBox(height: MediaQuery.of(context).padding.bottom),
+        ],
+      ),
+    );
+  }
+}
+
+// 점선을 그리는 CustomPainter
+class DashedLinePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.grey.shade300
+      ..strokeWidth = 1.0;
+
+    const dashWidth = 4.0;
+    const dashSpace = 4.0;
+    double startX = 0.0;
+
+    while (startX < size.width) {
+      canvas.drawLine(
+        Offset(startX, 0),
+        Offset(startX + dashWidth, 0),
+        paint,
+      );
+      startX += dashWidth + dashSpace;
+    }
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
+} 


### PR DESCRIPTION
## Changes

### 구조

- 대기(뽑기) 화면, 로또 화면, 결과(다시 뽑기) 화면을 한 페이지로 구성
- 같은 state 공유 -> 결과 화면에서도 기존에 선택한 호불호 요소가 유지됨


### 대기 화면

<img src="https://github.com/user-attachments/assets/e96dccd2-80a1-4487-a012-e0365eac2c3f" width="45%" alt="대기 화면" />

- 뽑기 버튼, 선호 선택, 불호 선택 버튼 생성
- "뽑기" 버튼을 누르면 로또 화면으로 전환

<div style="display: grid; grid-template-column: 1fr 1fr;">
<img width="45%" src="https://github.com/user-attachments/assets/e1a5a14f-d5b2-4237-81b0-f41dc7af5714" alt="선호도 화면" />
<img width="45%" src="https://github.com/user-attachments/assets/90e15650-6b19-401e-84db-f4cf203a5c6e" alt="선호도 화면" />
</div>

- 선호 / 불호 선택 bottom sheet 생성
- 선택한 호불호 요소 유지

### 결과 화면

<img src="https://github.com/user-attachments/assets/f7ed2be6-4c10-4cac-a798-ab65e133c0c5" width="45%" alt="결과 화면" />

- 기존에 선택한 호불호 요소를 수정할 수 있도록, 이전 상태를 그대로 유지
- "다시 뽑기" 버튼을 누르면 로또 화면으로 전환